### PR TITLE
functionality for checkin

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -8,6 +8,8 @@ import http from "http";
 
 import { userRouter } from "../backend/user/router";
 import { spaceRouter } from "../backend/space/router";
+import { requestRouter } from "../backend/request/router";
+import { checkinRouter } from "../backend/checkin/router";
 
 // Configure .env file
 dotenv.config();
@@ -48,6 +50,8 @@ app.use(
 
 app.use("/api/users", userRouter);
 app.use("/api/spaces", spaceRouter);
+app.use("/api/requests", requestRouter);
+app.use("/api/checkins", checkinRouter);
 
 app.get("/api", (req, res) => {
   res.status(200).json({

--- a/backend/checkin/collection.ts
+++ b/backend/checkin/collection.ts
@@ -53,6 +53,9 @@ class CheckInCollection {
         }
     }
 
+    static async findAllBySpace(spaceId: string): Promise<Array<HydratedDocument<CheckIn>>>{
+        return CheckInModel.find({space: spaceId});
+    }
 
 
 

--- a/backend/checkin/collection.ts
+++ b/backend/checkin/collection.ts
@@ -1,0 +1,60 @@
+import type { HydratedDocument, Types } from "mongoose";
+import type { CheckIn } from "./model";
+import CheckInModel from "./model";
+
+class CheckInCollection {
+
+    /**
+     * Add's a check in to collection, with corresponding count or count = 1, if 
+     * first check in at location
+     */
+    static async addOne(userId: string, spaceId: string): Promise<HydratedDocument<CheckIn>> {
+        //find yesterday's check in, if such exists; sorting by count and limit 1 is efficient because spark magic i guess?
+        const yesterdayCheckIn = await CheckInModel.find({}).sort({count:-1}).limit(1)
+        const yestCount: number = yesterdayCheckIn.pop()?.count?? 0;
+
+        const rightNow = new Date();
+        const checkin = new CheckInModel({
+            user: userId,
+            space: spaceId,
+            date: rightNow,
+            count: yestCount + 1
+        });
+        await checkin.save()
+        return checkin
+    }
+
+
+    static async findOneToday(userId: string, spaceId: string): Promise<HydratedDocument<CheckIn> | null>{
+        const rightNow = new Date();
+        return CheckInModel.findOne({
+            user: userId,
+            space: spaceId,
+            date: {$gte: rightNow.toDateString()} //query: {date in store is >= today's Date at 00:00}
+        });
+    }
+
+    static async findAll(): Promise<Array<HydratedDocument<CheckIn>>>{
+        return CheckInModel.find({});
+    }
+
+    static async findAllByUserSpace(userId: string | undefined, spaceId: string | undefined): Promise<Array<HydratedDocument<CheckIn>>>{
+        if (spaceId !== undefined && userId !== undefined){
+            return CheckInModel.find({
+                space: spaceId,
+                user: userId
+            });
+        }
+        else if (spaceId !== undefined){
+            return CheckInModel.find({space: spaceId});
+        }
+        else{
+            return CheckInModel.find({user: userId});
+        }
+    }
+
+
+
+
+}
+export default CheckInCollection;

--- a/backend/checkin/middleware.ts
+++ b/backend/checkin/middleware.ts
@@ -24,6 +24,21 @@ const isSessionUserNotCheckInToday = async(req: Request, res: Response, next: Ne
     next();
 }
 
+
+/**
+ * Group by userId and count number of check ins
+ */
+function countCheckInsByUser(checkIns: Array<HydratedDocument<CheckIn>>): Map<string, number>{
+    const allUserIds: Array<string> = checkIns.map( i => i.user)
+    const initialSums: Map<string, number> = new Map();
+    const finalSums = allUserIds.reduce(function(sums,entry){
+        sums.set(entry, (sums.get(entry) || 0) + 1);
+        return sums;
+    }, initialSums);
+    return finalSums;
+}
+
 export {
     isSessionUserNotCheckInToday,
+    countCheckInsByUser
 }

--- a/backend/checkin/middleware.ts
+++ b/backend/checkin/middleware.ts
@@ -1,0 +1,29 @@
+import SpaceCollection from "../space/collection";
+import UserCollection from "../user/collection";
+import type { Request, Response, NextFunction } from "express";
+import { exists } from "fs";
+
+import type { HydratedDocument } from "mongoose";
+
+import CheckInCollection from "./collection";
+import type { CheckIn } from "./model";
+
+/**
+ * Checks if current session user is allowed to check into space with req.params.place_id,
+ * in other words, has session user checked in space already today?
+ */
+const isSessionUserNotCheckInToday = async(req: Request, res: Response, next: NextFunction) => {
+
+    const todayCheckIn = await CheckInCollection.findOneToday(req.session.userId as string, req.params.place_id as string);
+    if (todayCheckIn){
+        res.status(403).json({
+            message: `User with userId: ${req.session.userId} already checked into ${req.params.place_id} today. Today's date: ${todayCheckIn.date}`
+        });
+        return;
+    }
+    next();
+}
+
+export {
+    isSessionUserNotCheckInToday,
+}

--- a/backend/checkin/model.ts
+++ b/backend/checkin/model.ts
@@ -1,0 +1,41 @@
+import type { Types } from "mongoose";
+import { Schema, model } from "mongoose";
+
+export type CheckIn = {
+    _id: Types.ObjectId; //mongoDB
+
+    /** corresponds to google Auth's userId token */
+    user: string;
+
+    /** corresponds to placeId of space */
+    space: string;
+
+    date: Date;
+
+    
+
+    /** Count of all checkins by this user at this space, including this one. */
+    count: number;
+}
+
+const CheckInSchema = new Schema({
+    user: {
+        type: String,
+        required: true
+    },
+    space: {
+        type: String,
+        required: true
+    },
+    date: {
+        type: Date,
+        required: true
+    },
+    count: {
+        type: Number,
+        required: true
+    },
+});
+
+const CheckInModel = model<CheckIn>("CheckIn", CheckInSchema);
+export default CheckInModel;

--- a/backend/checkin/router.ts
+++ b/backend/checkin/router.ts
@@ -1,0 +1,91 @@
+import type { Request, Response, NextFunction } from "express";
+import { Types } from "mongoose";
+import express from "express";
+
+import CheckInCollection from "./collection";
+import SpaceCollection from "../space/collection";
+import UserCollection from "../user/collection";
+
+import { constructCheckInResponse } from "./util";
+
+import * as userMiddleware from "../user/middleware"
+import * as spaceMiddleware from "../space/middleware"
+import * as checkInMiddleware from "./middleware"
+
+const router = express.Router();
+
+/**
+ * @name POST /api/checkin/session/{place_id}
+ */
+ router.post(
+    "/session/:place_id",
+    [
+        userMiddleware.isUserLoggedIn,
+        //validator for geolocation? [TODO]
+        spaceMiddleware.isPlaceExists,
+        checkInMiddleware.isSessionUserNotCheckInToday,
+    ],
+    async (req: Request, res: Response, next: NextFunction) => {
+        const newCheckIn = await CheckInCollection.addOne(req.session.userId as string, req.params.place_id);
+
+        res.status(201).json({
+            message: "Successfully checked in!",
+            checkin: constructCheckInResponse(newCheckIn)
+        });
+    }
+)
+
+/**
+ * @name GET /api/checkin/today/session/{place_id}
+ */
+router.get(
+    "/today/session/:place_id",
+    [
+        userMiddleware.isUserLoggedIn,
+        spaceMiddleware.isPlaceExists,
+        //checkInMiddleware.isSessionUserNotCheckInToday,
+    ],
+    async (req: Request, res: Response, next: NextFunction) => {
+        const todayCheckIn = await CheckInCollection.findOneToday(req.session.userId as string, req.params.place_id);
+        if (!todayCheckIn){
+            res.status(404).json({
+                message: "You have not checked in yet today."
+            });
+            return;
+        }
+        res.status(200).json({
+            checkin: todayCheckIn
+        });
+    }
+)
+
+/**
+ * @name GET /api/checkin?space=placeId&user=userId
+ */
+router.get(
+    "/",
+    [
+        spaceMiddleware.isPlaceQueryExists,
+        userMiddleware.isUserQueryExists
+    ],
+    async (req: Request, res: Response, next: NextFunction) => {
+        if (req.query.space !== undefined || req.query.user !== undefined){
+            next();
+            return;
+        }
+        const allCheckIns = await CheckInCollection.findAll();
+        res.status(200).json({
+            requests: allCheckIns.map(constructCheckInResponse)
+        });
+    },
+    async (req: Request, res: Response) => {
+        const space = await SpaceCollection.findOne(req.query.space as string);
+        const user = await UserCollection.findOneFromGapiUserId(req.query.user as string);
+        const checkIns = await CheckInCollection.findAllByUserSpace(user?.gapiUserId, space?.place_id);
+        res.status(200).json({
+            checkins: checkIns.map(constructCheckInResponse)
+        });
+    }
+)
+
+export { router as checkinRouter };

--- a/backend/checkin/router.ts
+++ b/backend/checkin/router.ts
@@ -88,4 +88,21 @@ router.get(
     }
 )
 
+/**
+ * @name GET /api/checkin/count/{place_id}
+ */
+router.get(
+    "/count/:place_id",
+    [
+        spaceMiddleware.isPlaceExists
+    ],
+    async (req: Request, res: Response, next: NextFunction) => {
+        const checkIns = await CheckInCollection.findAllBySpace(req.params.place_id);
+        const finalCheckInCounts: Map<string, number> = checkInMiddleware.countCheckInsByUser(checkIns);
+        res.status(200).json({
+            checkInCounts: Array.from( finalCheckInCounts ).map(([key, value]) => ({ userId: key, count: value }))
+        });
+    }
+)
+
 export { router as checkinRouter };

--- a/backend/checkin/util.ts
+++ b/backend/checkin/util.ts
@@ -4,16 +4,26 @@ import type { CheckIn } from "./model";
 
 type CheckInResponse = {
     _id: string; //mongoDB
-    user: string;
-    /** corresponds to google Auth's userId token */
 
-    space: string;
+    /** corresponds to google Auth's userId token */
+    user: string;
+
     /** corresponds to placeId of space */
+    space: string;
 
     date: string;
 
-    count: number;
     /** Count of all checkins by this user at this space, including this one. */
+    count: number;
+};
+
+type CheckInCountsResponse = {
+     /** corresponds to google Auth's userId token */
+    user: string;
+
+    /** Count of all checkins by this user at this space. */
+    count: number;
+
 };
 
 /**
@@ -39,6 +49,6 @@ const constructCheckInResponse = (checkin: HydratedDocument<CheckIn>): CheckInRe
       _id: checkinCopy._id.toString(),
       date: formatDate(checkinCopy.date)
     };
-  };
+};
   
   export { constructCheckInResponse };

--- a/backend/checkin/util.ts
+++ b/backend/checkin/util.ts
@@ -1,0 +1,44 @@
+import type { HydratedDocument } from "mongoose";
+import moment from "moment";
+import type { CheckIn } from "./model";
+
+type CheckInResponse = {
+    _id: string; //mongoDB
+    user: string;
+    /** corresponds to google Auth's userId token */
+
+    space: string;
+    /** corresponds to placeId of space */
+
+    date: string;
+
+    count: number;
+    /** Count of all checkins by this user at this space, including this one. */
+};
+
+/**
+ * Encode a date as an unambiguous string
+ *
+ * @param {Date} date - A date object
+ * @returns {string} - formatted date as string
+ */
+ const formatDate = (date: Date): string => moment(date).format('MMMM Do YYYY, h:mm:ss a');
+
+ /**
+ * @param {HydratedDocument<CheckIn>} 
+ * @returns {CheckInResponse} 
+ */
+const constructCheckInResponse = (checkin: HydratedDocument<CheckIn>): CheckInResponse => {
+    const checkinCopy: CheckIn = {
+      ...checkin.toObject({
+        versionKey: false, // Cosmetics; prevents returning of __v property
+      }),
+    };
+    return {
+      ...checkinCopy,
+      _id: checkinCopy._id.toString(),
+      date: formatDate(checkinCopy.date)
+    };
+  };
+  
+  export { constructCheckInResponse };

--- a/backend/request/router.ts
+++ b/backend/request/router.ts
@@ -19,6 +19,10 @@ const router = express.Router();
  */
 router.get(
     "/",
+    [
+        spaceMiddleware.isPlaceQueryExists,
+        userMiddleware.isUserQueryExists
+    ],
     async (req: Request, res: Response, next: NextFunction) => {
         if (req.query.space !== undefined || req.query.user !== undefined){
             next();
@@ -27,11 +31,11 @@ router.get(
         const allRequests = await PlaceRequestCollection.findAll();
         res.status(200).json({
             requests: allRequests.map(constructPlaceRequestResponse)
-        })
+        });
     },
     [
         userMiddleware.isUserLoggedIn,
-        placeRequestMiddleware.isValidGetPlaceRequestQuery
+        //placeRequestMiddleware.isValidGetPlaceRequestQuery
     ],
     async (req: Request, res: Response) => {
         const space = await SpaceCollection.findOne(req.query.space as string);
@@ -39,7 +43,7 @@ router.get(
         const allRequests = await PlaceRequestCollection.findByAuthorSpace(space?.place_id, user?.gapiUserId);
         res.status(200).json({
             requests: allRequests.map(constructPlaceRequestResponse)
-        })
+        });
     }
 )
 
@@ -92,7 +96,7 @@ router.delete(
         await PlaceRequestCollection.deleteOne(requestId);
         res.status(200).json({
             message: "Request was successfully deleted."
-        })
+        });
     }
 )
 

--- a/backend/request/util.ts
+++ b/backend/request/util.ts
@@ -37,7 +37,7 @@ type PlaceRequestResponse = {
 const formatDate = (date: Date): string => moment(date).format('MMMM Do YYYY, h:mm:ss a');
 
 /**
- * @param {HydratedDocument<PlaceReuqest>} 
+ * @param {HydratedDocument<PlaceRequest>} 
  * @returns {PlaceRequestResponse} 
  */
 const constructPlaceRequestResponse = (placeRequest: HydratedDocument<PlaceRequest>): PlaceRequestResponse => {

--- a/backend/space/middleware.ts
+++ b/backend/space/middleware.ts
@@ -41,9 +41,8 @@ const isPlaceAlreadyExists = async (req: Request, res: Response, next: NextFunct
 /**
  * Checks if place_id in req.params exists
  */
- const isPlaceExists = async (req: Request, res: Response, next: NextFunction) => {
+const isPlaceExists = async (req: Request, res: Response, next: NextFunction) => {
     const place_id: string = req.params.place_id
-    console.log(req.params)
     const space = await SpaceCollection.findOne(place_id);
     if (!space) {
       res.status(404).json({
@@ -54,10 +53,31 @@ const isPlaceAlreadyExists = async (req: Request, res: Response, next: NextFunct
     next();
 };
 
+/**
+ * Checks if place_id in req.query exists; move on if req.query not provided
+ */
+const isPlaceQueryExists = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.query.space){
+    next();
+    return;
+  }
+  const place_id: string = req.query.space as string;
+  const space = await SpaceCollection.findOne(place_id);
+  if (!space) {
+    res.status(404).json({
+      message: `Space with place_id: ${place_id} does not exist.`
+    });
+    return;
+  }
+  next();
+};
+
+
 
 
 export {
     isValidPlaceResponse,
     isPlaceAlreadyExists,
-    isPlaceExists
+    isPlaceExists,
+    isPlaceQueryExists
 }

--- a/backend/user/middleware.ts
+++ b/backend/user/middleware.ts
@@ -15,9 +15,9 @@ async function verifyGoogleAuthToken(
 ): Promise<TokenPayload | void> {
   const client = new OAuth2Client(req.body.client_id);
   const ticket = await client.verifyIdToken({
-    idToken: req.body.token,
-    audience:
-      "681310618538-s6g1aq6eposlcsh028n5gu8f68k8l56l.apps.googleusercontent.com",
+	idToken: req.body.token,
+	audience:
+	  "681310618538-s6g1aq6eposlcsh028n5gu8f68k8l56l.apps.googleusercontent.com",
   });
   const payload = ticket.getPayload();
   return payload;
@@ -33,13 +33,13 @@ async function createUserFromGapiAuth(
 ): Promise<HydratedDocument<User>> {
   const user = await UserCollection.findOneFromGapiUserId(payload.sub);
   if (!user) {
-    const newUser = await UserCollection.addOne(
-      payload.sub,
-      payload.name,
-      payload.picture,
-      payload.email
-    );
-    return newUser;
+	const newUser = await UserCollection.addOne(
+	  payload.sub,
+	  payload.name,
+	  payload.picture,
+	  payload.email
+	);
+	return newUser;
   }
   return user;
 }
@@ -49,10 +49,10 @@ async function createUserFromGapiAuth(
  */
 const isUserLoggedIn = (req: Request, res: Response, next: NextFunction) => {
   if (!req.session.userId) {
-    res.status(403).json({
-      message: "User is not logged in.",
-    });
-    return;
+	res.status(403).json({
+	  message: "User is not logged in.",
+	});
+	return;
   }
   next();
 };
@@ -62,10 +62,10 @@ const isUserLoggedIn = (req: Request, res: Response, next: NextFunction) => {
  */
 const isUserLoggedOut = (req: Request, res: Response, next: NextFunction) => {
   if (req.session.userId) {
-    res.status(403).json({
-      error: "You are already signed in.",
-    });
-    return;
+	res.status(403).json({
+	  error: "You are already signed in.",
+	});
+	return;
   }
 
   next();
@@ -76,16 +76,16 @@ const isUserLoggedOut = (req: Request, res: Response, next: NextFunction) => {
  */
 const isUserQueryExists = async (req: Request, res: Response, next: NextFunction) => {
   if (!req.query.user){
-    next();
-    return;
+	next();
+	return;
   }
   const userId: string = req.query.user as string;
   const user = await UserCollection.findOneFromGapiUserId(userId);
   if (!user) {
-    res.status(404).json({
-      message: `User with userId: ${userId} does not exist.`
-    });
-    return;
+	res.status(404).json({
+	  message: `User with userId: ${userId} does not exist.`
+	});
+	return;
   }
   next();
 };
@@ -96,17 +96,18 @@ const isCurrentSessionUserExists = async (
   next: NextFunction
 ) => {
   if (req.session.userId) {
-    const user = await UserCollection.findOneFromGapiUserId(req.session.userId);
-    if (!user) {
-      req.session.userId = undefined;
-      res.status(500).json({
-        message: "User session was not recognized.",
-      });
-      return;
-    }
+	const user = await UserCollection.findOneFromGapiUserId(req.session.userId);
+	if (!user) {
+	  req.session.userId = undefined;
+	  res.status(500).json({
+		message: "User session was not recognized.",
+	  });
+	  return;
+	}
   }
   next();
 };
+
 
 export {
   verifyGoogleAuthToken,

--- a/backend/user/middleware.ts
+++ b/backend/user/middleware.ts
@@ -71,6 +71,25 @@ const isUserLoggedOut = (req: Request, res: Response, next: NextFunction) => {
   next();
 };
 
+/**
+ * Checks if req.query.userId exists if provided, otherwise move on.
+ */
+const isUserQueryExists = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.query.user){
+    next();
+    return;
+  }
+  const userId: string = req.query.user as string;
+  const user = await UserCollection.findOneFromGapiUserId(userId);
+  if (!user) {
+    res.status(404).json({
+      message: `User with userId: ${userId} does not exist.`
+    });
+    return;
+  }
+  next();
+};
+
 const isCurrentSessionUserExists = async (
   req: Request,
   res: Response,
@@ -95,4 +114,5 @@ export {
   isUserLoggedIn,
   isUserLoggedOut,
   isCurrentSessionUserExists,
+  isUserQueryExists
 };

--- a/docs/paths/checkins.yml
+++ b/docs/paths/checkins.yml
@@ -1,0 +1,101 @@
+PATH_checkin_session:
+  post:
+    summary: Check in a user to a space
+    description: Check in the current session user into a space
+    parameters:
+      - in: path
+        name: place_id
+        required: true
+        schema:
+          type: string
+        description: corresponding placeId of space to check user into.
+    responses:
+      '201':
+        description: 'Created'
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: 
+                  type: string
+                checkin:
+                  $ref: '../schemas/_index.yml#/CheckIn'
+            example:
+              message: "Successfully checked in user."
+              checkin: {
+                  userId: "105454022127406520411",
+                  spaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4",
+                  date: "2022-11-23T22:31:29.847+00:00",
+                  count: 100
+              }
+
+PATH_checkin_today_session:
+  get:
+    summary: Get checkin for space for this current day
+    description: Can be used to validate if session user has already checked in to a space today
+    parameters:
+      - in: path
+        name: place_id
+        required: true
+        schema:
+          type: string
+        description: place_id of the Space of desired checkin
+    responses:
+      '200':
+        description: 'OK'
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: 
+                  type: string
+                checkin:
+                  $ref: '../schemas/_index.yml#/CheckIn'
+            example:
+              message: "Successfully found today's checkin."
+              checkin: {
+                  userId: "105454022127406520411",
+                  spaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4",
+                  date: "2022-11-23T22:31:29.847+00:00",
+                  count: 100
+              }
+
+PATH_checkin:
+  get:
+    summary: Get check ins for space/user combination
+    description: Get all the check ins that a given user has at a given space.
+    parameters:
+      - in: query
+        name: place_id
+        schema:
+          type: string
+        description: place_id of the Space of desired checkin
+      - in: query
+        name: userId 
+        schema:
+          type: string
+        description: google API userId of the desired checkin
+    responses:
+      '200':
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                checkins:
+                  type: array
+                  properties:
+                    checkin:
+                      $ref: '../schemas/_index.yml#/CheckIn'
+            example:
+              checkins: [
+                {
+                    userId: "105454022127406520411",
+                    spaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4",
+                    date: "2022-11-23T22:31:29.847+00:00",
+                    count: 100
+                }
+              ]

--- a/docs/paths/checkins.yml
+++ b/docs/paths/checkins.yml
@@ -99,3 +99,32 @@ PATH_checkin:
                     count: 100
                 }
               ]
+
+PATH_checkin_counts:
+  get:
+    summary: Get checkin counts for all users in this space
+    description: Get all counts of check ins for all users that have checked in to this space historically.
+    parameters:
+      - in: path
+        name: place_id
+        schema:
+          type: string
+        description: place_id of the Space of desired checkin count 
+    responses:
+      '200':
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/_index.yml#/checkInUserCountsResponse"
+            example:
+              checkInCounts : [
+                {
+                    userId: "105454022127406520411",
+                    count: 100
+                },
+                {
+                    userId: "294853249127406530284",
+                    count: 50
+                }
+              ]

--- a/docs/paths/requests.yml
+++ b/docs/paths/requests.yml
@@ -85,8 +85,8 @@ PATH_requests_post:
           schema:
             $ref: "../schemas/_index.yml#/requestCreatePayload"
     responses:
-      '200':
-        description: 'OK'
+      '201':
+        description: 'Created'
         content:
           application/json:
             schema:

--- a/docs/paths/spaces.yml
+++ b/docs/paths/spaces.yml
@@ -61,17 +61,20 @@ PATH_spaces:
             schema:
               type: object
               properties:
-                message:
-                  type: string
-                space: 
-                  $ref: "../schemas/_index.yml#/Space"
+                spaces: 
+                  type: array
+                  properties:
+                    space:
+                      $ref: "../schemas/_index.yml#/Space"
             example:
               {
-                space: {
-                  place_id: "ChIJN1t_tDeuEmsRUsoyG83frY4",
-                  formatted_address: "123 Apple St. Anchorage, AL 12345",
-                  name: "aPlaceInAlaska"
-                }
+                spaces: [
+                  {
+                    place_id: "ChIJN1t_tDeuEmsRUsoyG83frY4",
+                    formatted_address: "123 Apple St. Anchorage, AL 12345",
+                    name: "aPlaceInAlaska"
+                  }
+                ]
               }
       '404':
         description: 'Not Found'

--- a/docs/root.yml
+++ b/docs/root.yml
@@ -39,7 +39,8 @@ paths:
     $ref: "./paths/checkins.yml#/PATH_checkin_today_session"
   /api/checkins:
     $ref: "./paths/checkins.yml#/PATH_checkin"
-  
+  /api/checkins/count/{place_id}:
+    $ref: "./paths/checkins.yml#/PATH_checkin_counts"
 components:
   schemas:
     $ref: "./schemas/_index.yml"

--- a/docs/root.yml
+++ b/docs/root.yml
@@ -33,7 +33,13 @@ paths:
     $ref: "./paths/requests.yml#/PATH_requests_post"
   /api/requests:
     $ref: "./paths/requests.yml#/PATH_requests"
-
+  /api/checkins/session/{place_id}:
+    $ref: "./paths/checkins.yml#/PATH_checkin_session"
+  /api/checkins/today/session/{place_id}:
+    $ref: "./paths/checkins.yml#/PATH_checkin_today_session"
+  /api/checkins:
+    $ref: "./paths/checkins.yml#/PATH_checkin"
+  
 components:
   schemas:
     $ref: "./schemas/_index.yml"

--- a/docs/schemas/CheckIn.yml
+++ b/docs/schemas/CheckIn.yml
@@ -1,0 +1,16 @@
+type: object
+required:
+  - userId
+  - spaceId
+  - date
+  - count
+properties:
+  userId:
+    type: string
+  spaceId:
+    type: string
+  date:
+    type: string
+  count:
+    type: integer
+

--- a/docs/schemas/_index.yml
+++ b/docs/schemas/_index.yml
@@ -45,3 +45,14 @@ requestCreatePayload:
         type: string
     anonymous:
       type: boolean
+
+checkInUserCountsResponse:
+  type: array
+  properties:
+    checkInCounts:
+      type: object
+      properties:
+        userId:
+          type: string
+        count:
+          type: integer

--- a/docs/schemas/_index.yml
+++ b/docs/schemas/_index.yml
@@ -9,6 +9,9 @@ Place:
 
 PlaceRequest:
   $ref: "./PlaceRequest.yml"
+  
+CheckIn:
+  $ref: "./CheckIn.yml"
 
 gapiAuthPayload:
   type: object


### PR DESCRIPTION
routes for /checkin
some high level notes
- behavior for daily check in is handled by day -> if you already checked in at 12:01am you cannot check in again unti tomorrow
- check in model has an attribute called `count`. This corresponds to the count of total checks in by this user for this space. For front end, you probably want to do `max( allCheckIns.count )` which will return the current checkIn count for a given user/space combination. if needed, i can also implement this if it makes things easier just lmk 
- GET /checkins/today/session is just a checker to see if a user alr checked in to this space. it returns the check-in for today if such exists.

TODO:
- implement GET /checkins/counts/{place_id} to get something like 
`counts : [
user1: 100,
user2: 200,
user3: 150
...]` which would be used for the leaderboard