### PR TITLE
checkins and request ranking

### DIFF
--- a/backend/checkin/collection.ts
+++ b/backend/checkin/collection.ts
@@ -25,11 +25,11 @@ class CheckInCollection {
     }
 
 
-    static async findOneToday(userId: string, spaceId: string): Promise<HydratedDocument<CheckIn> | null>{
+    static async findOneToday(userId: string, /*spaceId: string*/): Promise<HydratedDocument<CheckIn> | null>{
         const rightNow = new Date();
         return CheckInModel.findOne({
             user: userId,
-            space: spaceId,
+            //space: spaceId,
             date: {$gte: rightNow.toDateString()} //query: {date in store is >= today's Date at 00:00}
         });
     }

--- a/backend/checkin/middleware.ts
+++ b/backend/checkin/middleware.ts
@@ -14,10 +14,10 @@ import type { CheckIn } from "./model";
  */
 const isSessionUserNotCheckInToday = async(req: Request, res: Response, next: NextFunction) => {
 
-    const todayCheckIn = await CheckInCollection.findOneToday(req.session.userId as string, req.params.place_id as string);
+    const todayCheckIn = await CheckInCollection.findOneToday(req.session.userId as string/*, req.params.place_id as string*/);
     if (todayCheckIn){
         res.status(403).json({
-            message: `User with userId: ${req.session.userId} already checked into ${req.params.place_id} today. Today's date: ${todayCheckIn.date}`
+            message: `User with userId: ${req.session.userId} already checked into ${todayCheckIn.space} today. Check in time: ${todayCheckIn.date}`
         });
         return;
     }

--- a/backend/checkin/router.ts
+++ b/backend/checkin/router.ts
@@ -36,17 +36,17 @@ const router = express.Router();
 )
 
 /**
- * @name GET /api/checkin/today/session/{place_id}
+ * @name GET /api/checkin/today/session
  */
 router.get(
-    "/today/session/:place_id",
+    "/today/session",
     [
         userMiddleware.isUserLoggedIn,
-        spaceMiddleware.isPlaceExists,
+        //spaceMiddleware.isPlaceExists,
         //checkInMiddleware.isSessionUserNotCheckInToday,
     ],
     async (req: Request, res: Response, next: NextFunction) => {
-        const todayCheckIn = await CheckInCollection.findOneToday(req.session.userId as string, req.params.place_id);
+        const todayCheckIn = await CheckInCollection.findOneToday(req.session.userId as string /*req.params.place_id*/);
         if (!todayCheckIn){
             res.status(404).json({
                 message: "You have not checked in yet today."
@@ -54,7 +54,7 @@ router.get(
             return;
         }
         res.status(200).json({
-            checkin: todayCheckIn
+            checkin: constructCheckInResponse(todayCheckIn)
         });
     }
 )

--- a/backend/request/router.ts
+++ b/backend/request/router.ts
@@ -10,7 +10,9 @@ import { constructPlaceRequestResponse } from "./util";
 
 import * as userMiddleware from "../user/middleware"
 import * as spaceMiddleware from "../space/middleware"
+import * as checkInMiddleware from "../checkin/middleware"
 import * as placeRequestMiddleware from "./middleware"
+import CheckInCollection from "../checkin/collection";
 
 const router = express.Router();
 
@@ -44,6 +46,22 @@ router.get(
         res.status(200).json({
             requests: allRequests.map(constructPlaceRequestResponse)
         });
+    }
+)
+
+/**
+ * @name GET /api/requests/checkin_ranked/{place_id}
+ */
+router.get(
+    "/checkin_ranked/:place_id",
+    [
+        spaceMiddleware.isPlaceExists
+    ],
+    async (req: Request, res: Response, next: NextFunction) => {
+        const requestsRanked = await PlaceRequestCollection.findRankedBySpace(req.params.place_id as string);
+        res.status(200).json({
+            requests: requestsRanked.map(constructPlaceRequestResponse)
+        })
     }
 )
 

--- a/backend/space/middleware.ts
+++ b/backend/space/middleware.ts
@@ -57,12 +57,12 @@ const isPlaceExists = async (req: Request, res: Response, next: NextFunction) =>
  * Checks if place_id in req.query exists; move on if req.query not provided
  */
 const isPlaceQueryExists = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.query.space){
+  if (!req.query.space && !req.query.place_id){
     next();
     return;
   }
-  const place_id: string = req.query.space as string;
-  const space = await SpaceCollection.findOne(place_id);
+  const place_id = req.query.space?? req.query.place_id;
+  const space = await SpaceCollection.findOne(place_id as string);
   if (!space) {
     res.status(404).json({
       message: `Space with place_id: ${place_id} does not exist.`

--- a/backend/space/router.ts
+++ b/backend/space/router.ts
@@ -46,10 +46,10 @@ router.delete(
 );
 
 /**
- * @name GET /api/spaces/{place_id}
+ * @name GET /api/spaces
  */
 router.get(
-  "/:place_id?",
+  "/",
   async (req: Request, res: Response, next: NextFunction) => {
     if (req.query.place_id !== undefined) {
       next();

--- a/backend/space/router.ts
+++ b/backend/space/router.ts
@@ -51,7 +51,7 @@ router.delete(
 router.get(
   "/:place_id?",
   async (req: Request, res: Response, next: NextFunction) => {
-    if (req.params.place_id !== undefined) {
+    if (req.query.place_id !== undefined) {
       next();
       return;
     }
@@ -61,10 +61,10 @@ router.get(
       spaces: allSpacesResponse, //[TODO] think about spaces vs. space... do we want to split this path into two?
     });
   },
-  [spaceMiddleware.isPlaceExists],
+  [spaceMiddleware.isPlaceQueryExists],
   async (req: Request, res: Response) => {
-    const place_id: string = req.params.place_id;
-    const space = await SpaceCollection.findOne(place_id);
+    const place_id = req.query.place_id;
+    const space = await SpaceCollection.findOne(place_id as string);
     if (!space) {
       res.status(404).json({
         message: `Space with place_id: ${place_id} does not exist.`,

--- a/docs/paths/checkins.yml
+++ b/docs/paths/checkins.yml
@@ -34,13 +34,6 @@ PATH_checkin_today_session:
   get:
     summary: Get checkin for space for this current day
     description: Can be used to validate if session user has already checked in to a space today
-    parameters:
-      - in: path
-        name: place_id
-        required: true
-        schema:
-          type: string
-        description: place_id of the Space of desired checkin
     responses:
       '200':
         description: 'OK'

--- a/docs/paths/requests.yml
+++ b/docs/paths/requests.yml
@@ -1,7 +1,7 @@
 PATH_requests:
   get:
     summary: Find a PlaceRequest
-    description: Used to get the request in collection based on placeId and/or userId. Returns all requests if no queries are given.
+    description: Used to get the request in collection based on placeId and/or userId. Returns all requests if no queries are given. Ordered by most recent to oldest.
     parameters:
       - in: query
         name: space
@@ -67,6 +67,47 @@ PATH_requests:
                   type: string
             example:
               message: "Request has successfully been deleted."
+  
+PATH_requests_checkinranked:
+  get:
+    summary: Get ranked requests by check_in user score.
+    description: Returns all the requests for a space, denoted by place_id param, ranked by requests with highest user-check_in score, then by request dateCreated recency.
+    parameters: 
+      - in: path
+        name: place_id
+        required: true
+        schema:
+          type: string
+    responses:
+      '200':
+        description: 'OK'
+        content:
+          application/json:
+            schema:
+              type: array
+              properties:
+                request: 
+                  $ref: "../schemas/_index.yml#/PlaceRequest"
+            example:
+              {
+                requests: [
+                  {
+                    "_id": "638a77f66e0efba60f844cad",
+                    "author": "105454022127406520411",
+                    "space": "ChIJN1t_tDeuEmsRUsoyG83frY4",
+                    "title": "my title",
+                    "textContent": "content",
+                    "dateCreated": "December 2nd 2022, 5:11:02 pm",
+                    "tags": [
+                      "hi"
+                    ],
+                    "anonymous": true,
+                    "upvotingUsers": [],
+                    "resolved": false,
+                    "inProcess": false
+                  }
+                ]
+              }
 PATH_requests_post:
   post:
     summary: Create a request

--- a/docs/paths/spaces.yml
+++ b/docs/paths/spaces.yml
@@ -10,7 +10,7 @@ PATH_spaces:
             $ref: "../schemas/_index.yml#/Place"
     responses:
       '201':
-        description: 'Created'
+        description: 'Created new space with google.maps.LatLngLiteral object and google.maps.places.PlacePhoto[] object as attributes.'
         content:
           application/json:
             schema:
@@ -46,16 +46,16 @@ PATH_spaces:
               message: "Provided place details do not have one of [place_id, formatted_address, name]"
   get:
     summary: Find a space
-    description: Used to get the space in collection based on spaceId. Returns all spaces if no spaceId parameter was given.
+    description: Used to get the space in collection based on place_id. Returns all spaces if no spaceId parameter was given.
     parameters:
-      - in: path
+      - in: query
         name: place_id
         required: false
         schema:
           type: string
     responses:
       '200':
-        description: 'OK'
+        description: 'OK. Found space with google.maps.LatLngLiteral object and google.maps.places.PlacePhoto[] object as attributes.'
         content:
           application/json:
             schema:

--- a/docs/root.yml
+++ b/docs/root.yml
@@ -35,7 +35,7 @@ paths:
     $ref: "./paths/requests.yml#/PATH_requests"
   /api/checkins/session/{place_id}:
     $ref: "./paths/checkins.yml#/PATH_checkin_session"
-  /api/checkins/today/session/{place_id}:
+  /api/checkins/today/session:
     $ref: "./paths/checkins.yml#/PATH_checkin_today_session"
   /api/checkins:
     $ref: "./paths/checkins.yml#/PATH_checkin"

--- a/docs/root.yml
+++ b/docs/root.yml
@@ -41,6 +41,8 @@ paths:
     $ref: "./paths/checkins.yml#/PATH_checkin"
   /api/checkins/count/{place_id}:
     $ref: "./paths/checkins.yml#/PATH_checkin_counts"
+  /api/requests/checkin_ranked/{place_id}:
+    $ref: "./paths/requests.yml#/PATH_requests_checkinranked"
   /api/replies/{request_id}:
     $ref: "./paths/replies.yml#/PATH_replies_post"
   /api/replies:

--- a/docs/schemas/Space.yml
+++ b/docs/schemas/Space.yml
@@ -20,3 +20,10 @@ properties:
     type: string
   website:
     type: string
+  latlng:
+    type: object
+    properties:
+      lat:
+        type: number
+      lng:
+        type: number


### PR DESCRIPTION
-  change `POST /checkins` so that it only allows user to create a SINGLE checkin per 24 hour period, regardless of space. previously, `POST /checkins` allowed users to checkin unlimited times if it were to unique spaces 
- add path `GET /requests/checkin_ranked/{place_id}` which gets all the requests for a given space, ranked first by user-checkin scores, then dateCreated (recent -> older)
- changed GET /spaces to use query parameter for `place_id` instead of path parameters. Should be the same functionality as #33 @dschaadt32 except for DELETE /spaces changes.

- added descriptions for space paths and updated Space Schema to explicate photos and latlngs, resolves #29 